### PR TITLE
fix: cycling through glob matches was not done correctly

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,7 +27,8 @@ use {
 
 ## ⚙️  Configuring
 You can pass custom extensions to the `extensions` table. Each extension should have at least two properties:
-1. `patterns`, a list of file glob patterns to run the autocomands for
+1. `patterns`, a list of file glob patterns to run the autocomands for.
+    Important: the plugin matches the glob on the file path of the current file now; meaning for example that setting `plugins.lua` won't match correctly but `*plugins.lua` will.
 2. `match_to_url`, a function to run the match and return the composed url to be used by the `gx` command
 
 The following is an example of hitting `gx` on a terraform file on a line where an aws resource is defined and opening your browser directly on the terraform registry documentation for the specific resource.

--- a/lua/gx-extended/extensions/package-json.lua
+++ b/lua/gx-extended/extensions/package-json.lua
@@ -15,7 +15,7 @@ end
 
 function M.setup(config)
   require("gx-extended.lib").register({
-    patterns = { "package.json" },
+    patterns = { "*package.json" },
     match_to_url = match_to_url,
   })
 end

--- a/lua/gx-extended/extensions/packer-plugins.lua
+++ b/lua/gx-extended/extensions/packer-plugins.lua
@@ -2,7 +2,7 @@ local M = {}
 
 function M.setup(config)
 	require("gx-extended.lib").register({
-		patterns = { "plugins.lua" },
+		patterns = { "*plugins.lua" },
 		match_to_url = function(line_string)
 			local line = string.match(line_string, "[\"|'].*/.*[\"|']")
 			local repo = vim.split(line, ":")[1]:gsub('"', "")

--- a/lua/gx-extended/extensions/user-extensions.lua
+++ b/lua/gx-extended/extensions/user-extensions.lua
@@ -10,7 +10,7 @@ function M.setup(config)
 			local success, _ = pcall(lib.register, registration)
 
 			if not success then
-				logger.warn("Failed to register gx-extended autocmd for " .. registration.pattern)
+				logger.warn("Failed to register gx-extended autocmd for " .. registration.patterns)
 			end
 		end
 	end)

--- a/lua/gx-extended/lib.lua
+++ b/lua/gx-extended/lib.lua
@@ -6,46 +6,51 @@ local registry = {}
 
 -- override with config.open_fn
 local function open_fn(url)
-  vim.api.nvim_call_function("netrw#BrowseX", { url, 0 })
+	vim.api.nvim_call_function("netrw#BrowseX", { url, 0 })
 end
 
 local function run_match_to_urls()
 	local line_string = vim.api.nvim_get_current_line()
-	local url, matched_pattern = nil, nil
+	local url, matched_patterns = nil, {}
 
 	local current_file = vim.fn.expand("%")
 
 	for file_glob, _ in pairs(registry) do
-    local file_pattern = vim.fn.glob2regpat(file_glob)
+		local file_pattern = vim.fn.glob2regpat(file_glob)
 		local match = vim.fn.matchstr(current_file, file_pattern)
 
-		if match ~= '' then
+		if match ~= "" then
 			logger.debug(
 				"Found match for current file pattern",
 				{ current_file = current_file, file_pattern = file_pattern, match = match }
 			)
 
-			matched_pattern = file_glob
+			table.insert(matched_patterns, file_glob)
 		end
 	end
 
-	if matched_pattern then
-		for _, pattern_value in ipairs(registry[matched_pattern]) do
-			logger.debug("pattern_value", pattern_value)
+	local keep_going = true
+	for _, matched_pattern in ipairs(matched_patterns) do
+		if keep_going then
+			for _, extension in ipairs(registry[matched_pattern]) do
+				logger.debug("pattern_value", extension)
 
-			local pcall_succeeded, _return = pcall(pattern_value.match_to_url, line_string)
-			url = pcall_succeeded and _return or nil
+				local pcall_succeeded, _return = pcall(extension.match_to_url, line_string)
+				url = pcall_succeeded and _return or nil
 
-			logger.debug("match_to_url called", {
-				line_string = line_string,
-				success = pcall_succeeded,
-				url = url or 'nil',
-				pattern_value = pattern_value,
-			})
+				logger.debug("match_to_url called", {
+					line_string = line_string,
+					success = pcall_succeeded,
+					url = url or "nil",
+					extension = extension,
+				})
 
-			if url then
-        open_fn(url)
-				break
+				if url ~= nil and url ~= "nil" then
+					logger.debug("opening url", { url = url, success = pcall_succeeded })
+					open_fn(url)
+          keep_going = false
+					break
+				end
 			end
 		end
 	end
@@ -61,9 +66,9 @@ end
 function M.setup(config)
 	logger.set_log_level(config.log_level)
 
-  if config.open_fn then
-    open_fn = config.open_fn
-  end
+	if config.open_fn then
+		open_fn = config.open_fn
+	end
 	vim.keymap.set("n", "gx", run_match_to_urls, {})
 end
 


### PR DESCRIPTION
This fixes it so that it attempts to call each match's open function until a successful call happens. Fixes #6.

TODOS:
~- Add note in the readme that patterns should be defined in glob pattern now since we're matching the whole path and not just the filename anymore.~