### PR TITLE
Add vim.ui.select picker for when multiple handlers are registered

### DIFF
--- a/lua/gx-extended/extensions/no-protocol-urls.lua
+++ b/lua/gx-extended/extensions/no-protocol-urls.lua
@@ -3,6 +3,7 @@ local M = {}
 function M.setup(config)
   require("gx-extended.lib").register {
     patterns = { "*" },
+    name = "no-protocol-urls",
     match_to_url = function(line_string)
       local patterns_with_http_s = "(https?://[a-zA-Z0-9_/%-.~@#+=?&%%A-Fa-f]+)"
       local patterns_without_http_s = "([a-zA-Z0-9_/%-.~@#+%%A-Fa-f]+%.[a-zA-Z0-9_/%-.~@#+%%A-Fa-f%=?&]+)"

--- a/lua/gx-extended/extensions/packer-plugins.lua
+++ b/lua/gx-extended/extensions/packer-plugins.lua
@@ -3,6 +3,7 @@ local M = {}
 function M.setup(config)
   require("gx-extended.lib").register {
     patterns = { "*plugins.lua" },
+    name = "neovim plugins",
     match_to_url = function(line_string)
       local line = string.match(line_string, "[\"|'].*/.*[\"|']")
       local repo = vim.split(line, ":")[1]:gsub('"', "")

--- a/lua/gx-extended/lib.lua
+++ b/lua/gx-extended/lib.lua
@@ -75,6 +75,11 @@ local function run_match_to_urls()
           end
         }, function(registration)
           logger.debug("selected", { registration = registration })
+          if not registration then
+            logger.debug("no registration selected")
+            return
+          end
+
           try_open(registration)
         end)
       else

--- a/lua/gx-extended/logger.lua
+++ b/lua/gx-extended/logger.lua
@@ -1,3 +1,9 @@
+--- @class Logger
+--- @field log_level string|number: The log level to use for the logger instance. Can be a string or a vim.log.levels enum value.
+--- @field debug fun(...): nil Writes a debug message to vim.notify, if the current log level is "debug".
+--- @field info fun(...): nil Writes a debug message to vim.notify, if the current log level is "debug".
+--- @field warn fun(...): nil Writes a debug message to vim.notify, if the current log level is "debug".
+--- @field error fun(...): nil Writes a debug message to vim.notify, if the current log level is "debug".
 local L = {}
 local plugin_name = "gx-extended"
 
@@ -17,7 +23,10 @@ local function to_print(...)
   end
 end
 
+--- Creates a new logger instance.
+--- @return Logger: The logger instance.
 function L:new(obj_and_config)
+  -- TODO: fix this? This might be a bad idea. The same object we're setting the class to is the object passed in as a config. Feels like it should be a new object instead and the config should just be the config.
   obj_and_config = obj_and_config or {}
 
   self = vim.tbl_deep_extend("force", self, obj_and_config)


### PR DESCRIPTION
Rework matching and opening functions for better multi-registration handling

The plugin now takes the following steps after `gx`:
1. Checks what glob patterns match the _absolute_ current path
1. For each of these matched patterns it tries calling `match_to_url`
1. If more than one succeeds it shows the selection menu through
   `vim.ui.select`. If not it opens the only succeeding call.

**Changes**
- Added debug logs for `registry` and `matched_patterns` in the `lib.lua` file.
- Modified the `try_open` function in the `lib.lua` file to handle multiple registrations.
- Added a select menu functionality when more than one handler is registered in the `lib.lua` file.
- Added a `name` property to the `RegistrationSpec` in the `lib.lua` file.
- Added a new `match_to_url` function to handle URLs with and without protocols in the `no-protocol-urls` extension in the `no-protocol-urls.lua` file.

**[lua/gx-extended/lib.lua]**
- Add debug log for `registry`
- Add debug log for `matched_patterns`
- Modify `try_open` to handle multiple registrations
- Show select menu when more than one handler registered
- Add `name` property to `RegistrationSpec` [lua/gx-extended/extensions/no-protocol-urls.lua]
- Add a new `match_to_url` function to handle URLs with and without protocols in the `no-protocol-urls` extension


https://github.com/rmagatti/gx-extended.nvim/assets/2881382/f7f09f3b-cd88-4f91-a1db-d2f4dc9246c2

Closes #10 