### PR TITLE
Improve debug logging and increase summary comment space

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -26,4 +26,4 @@ plugin/
 tmp/
 node_modules/
 
-lua/.luarc.json
+**/.luarc.json

--- a/lua/gx-extended/extensions/package-json.lua
+++ b/lua/gx-extended/extensions/package-json.lua
@@ -15,7 +15,7 @@ end
 
 function M.setup(config)
   require("gx-extended.lib").register {
-    patterns = { "*package.json" },
+    patterns = { "**/package.json" },
     name = "npm packages",
     match_to_url = match_to_url,
   }


### PR DESCRIPTION
Fix handling the return of `call_match_to_url` correctly. This would make some handlers like no-protocol-urls not work.

- Changed the pattern for matching `package.json` files to `**/package.json` in `lua/gx-extended/extensions/package-json.lua`
- Ignored `.luarc.json` in all directories in `.gitignore`
- Added debug logs and improved logging in various functions in `lua/gx-extended/lib.lua`
