### PR TITLE
Update/fix default "packer-plugins.lua" extension and spellcheck/format README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,12 +4,14 @@ A Neovim plugin that extends the functionality of the gx mapping.
 In Neovim, the `gx` mapping in normal mode allows you to navigate to the url under the cursor. This plugin extends that behaviour to more than just urls.
 
 ## 🎉 Built-in Features
-- `package.json` - `gx` when cursor is under an npm dependency, nagivates to _https://www.npmjs.com/package/[packageName]_
-- `plugins.lua` - In packer.nvim's convention `plugins.lua` file, `gx` when cursor is under an npm dependency, nagivates to _https://github.com/[user/org]/[repo]_
-- `*.tf` - In a [terraform](https://www.terraform.io/) file, `gx` when cursor is under a [terraform resource definition](https://developer.hashicorp.com/terraform/language/resources) nagivates to _https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/[resourceName]_
+
+- `package.json` - `gx` when cursor is under an npm dependency, navigates to _https://www.npmjs.com/package/[packageName]_
+- `plugins.lua` - In packer.nvim's convention `plugins.lua` file, `gx` when cursor is under a plugin dependency, navigates to _https://github.com/[user/org]/[repo]_
+- `*.tf` - In a [terraform](https://www.terraform.io/) file, `gx` when cursor is under a [terraform resource definition](https://developer.hashicorp.com/terraform/language/resources) navigates to _https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/[resourceName]_
 - `*` - In any file, `gx` navigates to no-protocol-urls like `google.com`, `docs.google.com`, etc.
 
 ## 🚀 Showcase
+
 Opening the registry docs for aws terraform resources
 
 https://user-images.githubusercontent.com/2881382/230259520-c2e84260-4e79-47ff-9c40-62a5162b15c0.mov
@@ -25,21 +27,24 @@ use {
 }
 ```
 
-## ⚙️  Configuring
+## ⚙️ Configuring
+
 You can pass custom extensions to the `extensions` table. Each extension should have at least two properties:
-1. `patterns`, a list of file glob patterns to run the autocomands for
-    Important: the plugin matches the glob on the file path of the current file now; meaning for example that setting `plugins.lua` won't match correctly but `*plugins.lua` will;
-1. `match_to_url`, a function to run the match and return the composed url to be used by the `gx` command;
-1. `name`, the name to be shown in a picker in case of handler/extension conflicts.
+
+1. `patterns`: a list of file glob patterns to run the autocommands for
+   - **Important:** The plugin matches the glob on the file path of the current file now; meaning for example that setting `plugins.lua` won't match correctly but `*plugins.lua` will.
+2. `match_to_url`: a function to run the match and return the composed url to be used by the `gx` command
+3. `name`: the name to be shown in a picker in case of handler/extension conflicts
 
 The following is an example of hitting `gx` on a terraform file on a line where an aws resource is defined and opening your browser directly on the terraform registry documentation for the specific resource.
+
 ```lua
 use {
   'rmagatti/gx-extended.nvim',
   config = function()
     require("gx-extended").setup {
       extensions = {
-        { -- match github repos in lazy.nvim plugin specs 
+        { -- match github repos in lazy.nvim plugin specs
           patterns = { '*/plugins/**/*.lua' },
           name = "neovim plugins",
           match_to_url = function(line_string)
@@ -55,9 +60,9 @@ use {
 }
 ```
 
-By default, gx-extended uses netrw to open urls. You can pass a custom open 
-function to config to change this behaviour. For example, if you use 
-`lazy.nvim`, you can  configure gx-extended to use it's `open` function:
+By default, gx-extended uses netrw to open urls. You can pass a custom open
+function to config to change this behaviour. For example, if you use
+`lazy.nvim`, you can configure gx-extended to use it's `open` function:
 
 ```lua
 return { 'rmagatti/gx-extended.nvim',
@@ -69,7 +74,9 @@ return { 'rmagatti/gx-extended.nvim',
 ```
 
 ## TODOs
+
 - Implement `visual` mode
 
 ### Inspiration/Alternatives
+
 https://github.com/stsewd/gx-extended.vim

--- a/lua/gx-extended/extensions/packer-plugins.lua
+++ b/lua/gx-extended/extensions/packer-plugins.lua
@@ -6,7 +6,7 @@ function M.setup(config)
     name = "neovim plugins",
     match_to_url = function(line_string)
       local line = string.match(line_string, "[\"|'].*/.*[\"|']")
-      local repo = vim.split(line, ":")[1]:gsub('"', "")
+      local repo = vim.split(line, ":")[1]:gsub("[\"|']", "")
       local url = "https://github.com/" .. repo
 
       if not line or not repo then


### PR DESCRIPTION
Hey @rmagatti, thank you for the great plugin!

This PR has the following changes:

1. When using the default [`packer-plugins.lua` extension](https://github.com/rmagatti/gx-extended.nvim/blob/main/lua/gx-extended/extensions/packer-plugins.lua) that's built into this plugin, I noticed that [only double quotes are replaced with an empty string](https://github.com/rmagatti/gx-extended.nvim/blob/main/lua/gx-extended/extensions/packer-plugins.lua#L9) before navigating to the plugin's Github URL. For my plugins file, I am using single quotes (i.e. `{ 'christoomey/vim-tmux-navigator', lazy = false, },`), so this extension was incorrectly taking me to `https://github.com/'christoomey/vim-tmux-navigator'` instead of `https://github.com/christoomey/vim-tmux-navigator`. In my fix, I'm simply replacing both double AND single quotes like the example extension in the README.
    - I have tried using another custom extension like the README describes but this is resulting in the default `packer-plugins.lua` and my custom extension conflicting with each other as they both act on my `plugins.lua` file. I am using NVChad and it requires placing plugins in a `plugins.lua` file: https://nvchad.com/docs/config/plugins#manage_custom_plugins.

2. I have also spell checked a few words and formatted the `README.md`, please let me know if any formatting is not desired and I can revert as needed.