### PR TITLE
Add visual mode support

### DIFF
--- a/lua/gx-extended/lib.lua
+++ b/lua/gx-extended/lib.lua
@@ -154,6 +154,7 @@ function M.setup(config)
     logger.debug("open_fn was overridden")
   end
   vim.keymap.set("n", "gx", run_match_to_urls, {})
+  vim.keymap.set("v", "gx", run_match_to_urls, {})
 end
 
 ---@class RegistrationSpec


### PR DESCRIPTION
Also bind to `gx` in visual mode.

Fixes #18
