### PR TITLE
Add PyPI integration

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,6 +9,7 @@ In Neovim, the `gx` mapping in normal mode allows you to navigate to the url und
 - `plugins.lua` - In packer.nvim's convention `plugins.lua` file, `gx` when cursor is under a plugin dependency, navigates to _https://github.com/[user/org]/[repo]_
 - `*.tf` - In a [terraform](https://www.terraform.io/) file, `gx` when cursor is under a [terraform resource definition](https://developer.hashicorp.com/terraform/language/resources) navigates to _https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/[resourceName]_. This works for both AWS and Google Cloud resources.
 - `Cargo.toml` - In a Cargo.toml file, gx on a line that contains a crate will take you to https://crates.io/crates/{{crate_name}}
+- `PyPI` - In a `Pipfile` or `requirements.txt` file, `gx` on a line that contains a package spec will take you to https://pypi.org/project/{{package}}
 - `*` - In any file, `gx` navigates to no-protocol-urls like `google.com`, `docs.google.com`, etc.
 
 ## 🚀 Showcase

--- a/lua/gx-extended/extensions/pypi-packages.lua
+++ b/lua/gx-extended/extensions/pypi-packages.lua
@@ -1,0 +1,24 @@
+local M = {}
+
+local match_to_url = function(line_string)
+  -- PyPA package naming convention: 
+  -- https://packaging.python.org/en/latest/specifications/name-normalization/#name-format
+  local pkg = string.match(line_string, '[%w][%w._-]*[%w]')
+  if not pkg then
+    return nil
+  end
+
+  local url = "https://pypi.org/project/" .. pkg
+
+  return url
+end
+
+function M.setup(config)
+  require("gx-extended.lib").register {
+    patterns = { "**/Pipfile", "**/requirements.txt" },
+    name = "pypi.org",
+    match_to_url = match_to_url,
+  }
+end
+
+return M

--- a/lua/gx-extended/init.lua
+++ b/lua/gx-extended/init.lua
@@ -19,6 +19,7 @@ function M.setup(config)
   require("gx-extended.extensions.terraform-google-resources").setup(config)
   require("gx-extended.extensions.no-protocol-urls").setup(config)
   require("gx-extended.extensions.cargo-toml").setup(config)
+  require("gx-extended.extensions.pypi-packages").setup(config)
 
   --- Setup user extensions
   require("gx-extended.extensions.user-extensions").setup(config)


### PR DESCRIPTION
## PyPI Integration

Hello!

Submitting integration for `PyPI` packages. The extension assumes the file is called `Pipfile` or `requirements.txt`, and opens https://pypi.org/project/{{package}}. I also took the liberty to add this feature to the `README` file.

According to the specification, a `PyPI` package name must conform to the following case-insensitive regex:

```regex
^([A-Z0-9]|[A-Z0-9][A-Z0-9._-]*[A-Z0-9])$
```

In other words: either be a single alphanumeric character; or start and end with alphanumeric characters and have any number of alphanumeric, period, underscore or dash characters in the middle. I didn't implement the single character case (although it seems they do exist, for example https://pypi.org/project/u/).

### References

PyPI package or project naming convention is specified at https://packaging.python.org/en/latest/specifications/name-normalization/#name-format